### PR TITLE
Changed 'Add an user' to 'Add a user'

### DIFF
--- a/static/resources/user/userpicker.js
+++ b/static/resources/user/userpicker.js
@@ -24,7 +24,7 @@ $.fn.userpicker = function (options) {
         focus: false,
         userGuid: "",
         data: {},
-        placeholderText: 'Add an user'
+        placeholderText: 'Add a user'
     }, options);
 
     var chosen = "";


### PR DESCRIPTION
'Add a user' is the correct form in English.  Use of 'a' or 'an' are not determined by spelling, but pronunciation. Any word which sounds like it begins with a vowel (it may or may not actually begin with a vowel) will take 'an' and any word which begins with sound of a consonant will take 'a' as the preceding article.